### PR TITLE
Some QoL changes #1

### DIFF
--- a/client/config/config.lua
+++ b/client/config/config.lua
@@ -1,9 +1,6 @@
 QBCore = exports['qb-core']:GetCoreObject()
 
 Config = {
-
-    Debug = true,
-
     SpeedTest = {
         -- We'll record acceleration of 0-n and braking speeds of n-0
         -- where n is each speed in this table.
@@ -21,7 +18,7 @@ Config = {
         -- This is where we wanna floor it towards
         Target = {
             Coords = vector3(-1409.37, -2342.89, 13.27),
-        }
+        },
     },
 
     --[[
@@ -125,9 +122,12 @@ Config = {
         ---@param vehicle table The vehicle entity
         -- FixVehicleFunction = nil,
         FixVehicleFunction = function(vehicle)
-            print("Custom function used to fix!")
             TriggerEvent('iens:repaira')
             TriggerEvent('vehiclemod:client:fixEverything')
+        end,
+
+        DeleteVehicleFunction = function(vehicle)
+            TriggerEvent('QBCore:Command:DeleteVehicle', vehicle)
         end,
     }
 }

--- a/client/services/speedtest_service.lua
+++ b/client/services/speedtest_service.lua
@@ -281,7 +281,7 @@ function SpeedTestService.RunMultipleTests(vehicles, type, groupId, categoryName
     local player = PlayerPedId()
     Context.SpeedTest.IsRunning = true
 
-    TriggerEvent("QBCore:Command:DeleteVehicle", player)
+    Config.Custom.DeleteVehicleFunction(vehicle)
 
     for _, data in ipairs(runDetails) do
         if not Context.SpeedTest.IsRunning then
@@ -356,18 +356,29 @@ function SpeedTestService.RunMultipleTests(vehicles, type, groupId, categoryName
 
         Wait(1000)
 
+        local i = 0
+
         while SpeedTestService._IsAccelerating(vehicle) do
-            Wait(6)
+            Wait(2)
+            i = i + 1
+            if i == 100 then
+                if not IsPedInAnyVehicle(player, false) then
+                    goto FinishThisTest
+                end
+
+                i = 0
+            end
         end
 
         while GetEntitySpeed(vehicle) > 0.1 do
             TaskVehicleTempAction(player, vehicle, 24, 6)
             SetVehicleBrake(vehicle, true)
-            Wait(6)
+            Wait(2)
         end
 
         Wait(Config.WaitBetweenMajorActions)
 
+        :: FinishThisTest ::
         table.insert(results, {
             VehicleData = vehicleData,
             IsUpgraded = data.type == TestType.WithUpgrades or data.type == TestType.WithCustomUpgrades,
@@ -377,7 +388,7 @@ function SpeedTestService.RunMultipleTests(vehicles, type, groupId, categoryName
         })
 
         Wait(100)
-        TriggerEvent('QBCore:Command:DeleteVehicle', player)
+        Config.Custom.DeleteVehicleFunction(vehicle)
     end
 
     SpeedTestService.EndTests(groupId, categoryName, results, false)

--- a/server/database/repositories/speed_test_repository.lua
+++ b/server/database/repositories/speed_test_repository.lua
@@ -59,10 +59,13 @@ function SpeedTestRepository.GetAllByGroupID(groupId)
             results_json,
             was_cancelled,
             is_deleted,
-            DATE_FORMAT(time_created, '%D %b %Y at %H:%i') AS time_created
+            DATE_FORMAT(time_created, '%D %b %Y at %H:%i') AS time_formatted
         FROM telemetry_speed_tests
         WHERE   group_id = @groupId
         AND     is_deleted = 0
+        ORDER BY
+                time_created DESC
+
     ]], {
         ["@groupId"] = groupId,
     })
@@ -92,11 +95,13 @@ function SpeedTestRepository.GetAllBy(keyValues, outFunc)
             results_json,
             was_cancelled,
             is_deleted,
-            DATE_FORMAT(time_created, '%D %b %Y at %H:%i') AS time_created
+            DATE_FORMAT(time_created, '%D %b %Y at %H:%i') AS time_formatted
         FROM    telemetry_speed_tests
         WHERE 
     ]] .. table.concat(segments, " AND ") .. [[
         AND is_deleted = 0
+        ORDER BY
+            time_created DESC
     ]]
 
     local results = MySQL.query.await(query, bindings)

--- a/shared/config/config.lua
+++ b/shared/config/config.lua
@@ -1,6 +1,8 @@
 QBCore = exports['qb-core']:GetCoreObject()
 
 SharedConfig = {
+    Debug = false,
+
     Vehicles = SharedUtils.GroupBy(QBCore.Shared.Vehicles, "category"),
 
     -- Note for the following:

--- a/shared/entities/speed_test_entity.lua
+++ b/shared/entities/speed_test_entity.lua
@@ -63,6 +63,6 @@ function SpeedTestEntity.CreateFromDatabaseResult(result)
         result.results_json,
         result.was_cancelled,
         result.is_deleted,
-        result.time_created
+        result.time_formatted
     )
 end


### PR DESCRIPTION
- Delete vehicle to skip test - will add menu option for this too eventually but you can literally /dv now
  - Tightened the accel/braking loops from 6ms to 2ms
  - Increment one each time and on 100 check we're still in a vehicle
    - If not in vehicle, jump to next test and store whatever results we collected
    - If in vehicle we'll just set the counter back to 0
- Re-order past runs so most recent runs appear first
  - Had to feed back time_formatted instead of time_created so I could order by the table's default data type
    - The alteration to the entity is for this reason
- Add custom delete vehicle function to client config
  - It was brought to my attention (thanks porky) that different servers had different delete vehicle functions! Whodathunkit. Anyway, that function is now in the client config and can be overridden.
- Set debug to false in shared config and remove it from client config
  - I accidentally left the debug flag in the client config but not in the shared config. Everywhere is checking the shared config, so I moved this over and also defaulted it to false.